### PR TITLE
Fix useMessageListener parameters

### DIFF
--- a/packages/flutter_comms/CHANGELOG.md
+++ b/packages/flutter_comms/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.5
+
+- **Breaking:** Change `useMessageListener`s `onInitialMessage` and `keys` to named parameters (#47)
+
 ## 0.0.4+1
 
 - Upgrade comms package

--- a/packages/flutter_comms/lib/src/use_message_listener.dart
+++ b/packages/flutter_comms/lib/src/use_message_listener.dart
@@ -7,10 +7,10 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 /// Works similarly to [Listener] but handles starting receiving messages and
 /// cleaning up itself.
 void useMessageListener<Message>(
-  OnMessage<Message> onMessage, [
+  OnMessage<Message> onMessage, {
   OnMessage<Message>? onInitialMessage,
   List<Object?> keys = const <Object>[],
-]) {
+}) {
   use(
     _MessageListenerHook<Message>(
       onMessage: onMessage,

--- a/packages/flutter_comms/pubspec.yaml
+++ b/packages/flutter_comms/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_comms
 description: Simple communication pattern abstraction on streams, created for communication between blocs and or widgets.
-version: 0.0.4+1
+version: 0.0.5
 homepage: https://github.com/leancodepl/comms
 
 environment:
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   bloc: ^8.1.0
-  comms: ^0.0.8+1
+  comms: ^0.0.8+2
   flutter:
     sdk: flutter
   flutter_hooks: ^0.18.2


### PR DESCRIPTION
You had to pass empty onInitialMessage to pass the keys to the useMessageListener hook, now onInitialMessage and keys will be named.

* Bump comms

* Update CHANGELOG and pubspec

* Change optional useMessageListener parameters to named