### PR TITLE
Fix useMessageListeners onInitialMessage getting called during build

### DIFF
--- a/packages/flutter_comms/CHANGELOG.md
+++ b/packages/flutter_comms/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.6
+
+- Fix `useMessageListener`s `onInitialMessage` getting called during build (#49)
+
 ## 0.0.5
 
 - **Breaking:** Change `useMessageListener`s `onInitialMessage` and `keys` to named parameters (#47)

--- a/packages/flutter_comms/lib/flutter_comms.dart
+++ b/packages/flutter_comms/lib/flutter_comms.dart
@@ -1,5 +1,3 @@
-library flutter_comms;
-
 export 'package:comms/comms.dart';
 
 export 'src/listener_bloc.dart';

--- a/packages/flutter_comms/lib/src/use_message_listener.dart
+++ b/packages/flutter_comms/lib/src/use_message_listener.dart
@@ -14,6 +14,7 @@ void useMessageListener<Message>(
   use(
     _MessageListenerHook<Message>(
       onMessage: onMessage,
+      onInitialMessage: onInitialMessage,
       keys: keys,
     ),
   );
@@ -47,8 +48,11 @@ class _MessageListenerHookState<Message>
   void onMessage(Message message) => hook.onMessage(message);
 
   @override
-  void onInitialMessage(Message message) =>
-      hook.onInitialMessage?.call(message);
+  void onInitialMessage(Message message) {
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => hook.onInitialMessage?.call(message),
+    );
+  }
 
   @override
   void dispose() {

--- a/packages/flutter_comms/pubspec.yaml
+++ b/packages/flutter_comms/pubspec.yaml
@@ -1,15 +1,15 @@
 name: flutter_comms
 description: Simple communication pattern abstraction on streams, created for communication between blocs and or widgets.
-version: 0.0.5
+version: 0.0.6
 homepage: https://github.com/leancodepl/comms
 
 environment:
   sdk: ">=2.16.0 <3.0.0"
-  flutter: ">=2.10.0 <4.0.0"
+  flutter: ">=2.17.0 <4.0.0"
 
 dependencies:
   bloc: ^8.1.0
-  comms: ^0.0.8+2
+  comms: ^0.0.9
   flutter:
     sdk: flutter
   flutter_hooks: ^0.18.2
@@ -21,4 +21,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  leancode_lint: ^1.1.0
+  leancode_lint: ^2.1.0


### PR DESCRIPTION
* Use addPostFrameCallback for scheduling onInitialMessage after build is done

* Bump comms package

* Update changelog and pubspec