### PR TITLE
Fix one off messaging when there is any active Listener

### DIFF
--- a/packages/comms/CHANGELOG.md
+++ b/packages/comms/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.10
+
+- Fix one off messages getting buffered when there is any active `Listener`
+
 ## 0.0.9
 
 - Add `oneOff` to `send()` for marking message as available to read only once

--- a/packages/comms/CHANGELOG.md
+++ b/packages/comms/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.10
 
-- Fix one off messages getting buffered when there is any active `Listener`
+- Fix one off messages getting buffered when there are active `Listener`s (#54)
 
 ## 0.0.9
 

--- a/packages/comms/lib/src/message_sink_register.dart
+++ b/packages/comms/lib/src/message_sink_register.dart
@@ -88,9 +88,14 @@ class MessageSinkRegister {
   /// Adds [message] to all sinks in [MessageSinkRegister]'s [_messageSinks]
   /// of type [Message] and updates [_messageBuffers].
   void sendToSinksOfType<Message>(Message message, {bool oneOff = false}) {
-    getSinksOfType<Message>().forEach(
-      (sink) => sink.add(message),
-    );
+    final sinks = getSinksOfType<Message>()
+      ..forEach(
+        (sink) => sink.add(message),
+      );
+
+    if (sinks.isNotEmpty && oneOff) {
+      return;
+    }
 
     _messageBuffers[Message] = _BufferedMessage<Message>(
       message: message,

--- a/packages/comms/lib/src/sender.dart
+++ b/packages/comms/lib/src/sender.dart
@@ -13,8 +13,10 @@ typedef Send<Message> = void Function(Message message, {bool oneOff});
 mixin Sender<Message> {
   /// Sends [message] to all [Listener]s of type [Message].
   ///
-  /// When [oneOff] is `true` [message] will be removed from the buffer after
-  /// the first [Listener] of same type calls listen().
+  /// When [oneOff] is `true` [message] will only be received by any [Listener]
+  /// currenlty listening for type [Message] or if there aren't any it will only
+  /// be received by the first [Listener] that calls `listen()` in
+  /// `onInitialMessage()`.
   @protected
   @nonVirtual
   void send(Message message, {bool oneOff = false}) {

--- a/packages/comms/lib/src/sender.dart
+++ b/packages/comms/lib/src/sender.dart
@@ -13,8 +13,8 @@ typedef Send<Message> = void Function(Message message, {bool oneOff});
 mixin Sender<Message> {
   /// Sends [message] to all [Listener]s of type [Message].
   ///
-  /// When [oneOff] is `true` [message] will only be received by any [Listener]
-  /// currenlty listening for type [Message] or if there aren't any it will only
+  /// When [oneOff] is `true`, [message] will only be received by any [Listener]
+  /// currently listening for type [Message]. If there aren't any it will only
   /// be received by the first [Listener] that calls `listen()` in
   /// `onInitialMessage()`.
   @protected

--- a/packages/comms/pubspec.yaml
+++ b/packages/comms/pubspec.yaml
@@ -1,10 +1,10 @@
 name: comms
 description: Simple communication pattern abstraction on streams, created for communication between logic classes.
-version: 0.0.9+1
+version: 0.0.10
 homepage: https://github.com/leancodepl/comms
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <=3.0.0"
 
 dependencies:
   logging: ^1.0.2


### PR DESCRIPTION
* update changelog and pubspec

* change MessageSinkRegister sendToSinksOfType() to not add one off messages to buffer when there is any active Listener

* update Sender send() doc comment