### PR TITLE
Add state management to ui example in readme

### DIFF
--- a/packages/comms/README.md
+++ b/packages/comms/README.md
@@ -11,7 +11,7 @@ For use in Flutter projects, check out [flutter_comms].
 ## Installation
 
 ```console
-$ dart pub add comms
+dart pub add comms
 ```
 
 ## Basic usage

--- a/packages/flutter_comms/README.md
+++ b/packages/flutter_comms/README.md
@@ -10,7 +10,7 @@ For use in dart only projects, use [comms].
 ## Installation
 
 ```console
-$ flutter pub add flutter_comms
+flutter pub add flutter_comms
 ```
 
 ## Basic usage
@@ -57,7 +57,7 @@ MultiMessageListener(
 
 ### useMessageListener
 
-`useMessageListener` hook calls `onMessage` everytime a message of type `Message`
+`useMessageListener` hook calls `onMessage` every time a message of type `Message`
 is received. Works similarly to `Listener` but handles starting message receiving
 and cleaning up itself.
 
@@ -76,6 +76,64 @@ Widget build(BuildContext context) {
 }
 ```
 
+## Sending messages from State Management to UI
+
+A typical real life use case of comms pattern is showing a toast or some popup with error
+or info message. States of any state management could be used for that but they are
+preserved even after the toast naturally disappears, so you have to clean the state yourself.
+With comms it's much more convenient.
+
+```dart
+class AuthNotifier with ChangeNotifier, Sender<AuthError> {
+  AuthNotifier(AuthRepository authRepository)
+    : _authRepository = authRepository;
+
+  final AuthRepository _authRepository;
+
+  bool _authenticated;
+  bool get authenticated => _authenticated;
+
+  Future<void> login(String username, String password) async {
+    try {
+      final loggedIn = await _authRepository.login(username, password);
+
+      if (loggedIn) {
+        _authenticated = true;
+        notifyListeners();
+      } else {
+        // All messages are cached to be able to use `onInitialMessage`. This
+        // time we need to set `oneOff` to `true`, otherwise on each Widget
+        // rebuild this message would be received. This still allows your
+        // widget to receive the message even if it gets build after message
+        // is sent, provided that this widget will be the first to receive it.
+        send(AuthError(message: 'Incorrect credentials'), oneOff: true);
+      }
+    } catch (e, st) {
+      send(AuthError(message: 'An unexpected error occurred'), oneOff: true);
+    }
+  }
+...
+}
+```
+
+We can use `AuthError` messages as single-time events which disappear instantly after
+displaying a snack bar, so no manual clean up is required. 
+
+```dart
+class LoginScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MessageListener<AuthError>(
+      onMessage: (authError) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text(authError.message)),
+        );
+      },
+      child: LoginForm(),
+    );
+  }
+}
+```
 
 [flutter_comms-pub-badge]: https://img.shields.io/pub/v/flutter_comms
 [flutter_comms-pub-badge-link]: https://pub.dev/packages/flutter_comms

--- a/packages/flutter_comms/README.md
+++ b/packages/flutter_comms/README.md
@@ -93,7 +93,7 @@ class AuthNotifier with ChangeNotifier, Sender<AuthError> {
   bool _authenticated;
   bool get authenticated => _authenticated;
 
-  Future<void> login(String username, String password) async {
+  Future<void> logIn(String username, String password) async {
     try {
       final loggedIn = await _authRepository.login(username, password);
 


### PR DESCRIPTION
- remove dollar signs from comms and flutter_comms installation step

- add Sending messages from State Management to UI section to flutter_comms readme

Closes #69